### PR TITLE
Fix all API_BASE_URLs to avoid consecutive slashes in URLs.

### DIFF
--- a/src/env/config/prod/index.js
+++ b/src/env/config/prod/index.js
@@ -4,7 +4,7 @@
 // changes should be done in the  /env/config/ files
 ////////////////////////////////////////////////////////////////////////////////////////////////
 const config = {
-	API_BASE_URL: '//data.ssb.no/api/klass/v1/',
+	API_BASE_URL: '//data.ssb.no/api/klass/v1',
 	API_LOCAL_BASE_URL: 'http://localhost:3001',
 	API_LOCAL_STORAGE: false,
 	OM_KLASS_URL: 'https://www.ssb.no/metadata/om-klass',

--- a/src/env/config/prod_nocache/index.js
+++ b/src/env/config/prod_nocache/index.js
@@ -4,7 +4,7 @@
 // changes should be done in the  /env/config/ files
 ////////////////////////////////////////////////////////////////////////////////////////////////
 const config = {
-	API_BASE_URL: 'http://pl-klass-app-p1.ssb.no:8080/api/klass/v1/',
+	API_BASE_URL: 'http://pl-klass-app-p1.ssb.no:8080/api/klass/v1',
 	API_LOCAL_BASE_URL: 'http://localhost:3001',
 	API_LOCAL_STORAGE: false,
 	OM_KLASS_URL: 'https://www.ssb.no/metadata/om-klass',

--- a/src/env/config/qa/index.js
+++ b/src/env/config/qa/index.js
@@ -4,7 +4,7 @@
 // changes should be done in the  /env/config/ files
 ////////////////////////////////////////////////////////////////////////////////////////////////
 const config = {
-	API_BASE_URL: '//data.qa.ssb.no/api/klass/v1/',
+	API_BASE_URL: '//data.qa.ssb.no/api/klass/v1',
 	API_LOCAL_BASE_URL: 'http://localhost:3001',
 	API_LOCAL_STORAGE: false,
 	OM_KLASS_URL: 'https://www.ssb.no/metadata/om-klass',

--- a/src/env/config/qa_nocache/index.js
+++ b/src/env/config/qa_nocache/index.js
@@ -4,7 +4,7 @@
 // changes should be done in the  /env/config/ files
 ////////////////////////////////////////////////////////////////////////////////////////////////
 const config = {
-	API_BASE_URL: 'http://pl-klass-app-qa1.ssb.no:8080/api/klass/v1/',
+	API_BASE_URL: 'http://pl-klass-app-qa1.ssb.no:8080/api/klass/v1',
 	API_LOCAL_BASE_URL: 'http://localhost:3001',
 	API_LOCAL_STORAGE: false,
 	OM_KLASS_URL: 'https://www.ssb.no/metadata/om-klass',

--- a/src/env/config/test/index.js
+++ b/src/env/config/test/index.js
@@ -4,7 +4,7 @@
 // changes should be done in the  /env/config/ files
 ////////////////////////////////////////////////////////////////////////////////////////////////
 const config = {
-	API_BASE_URL: 'https://data.test.ssb.no/api/klass/v1/',
+	API_BASE_URL: 'https://data.test.ssb.no/api/klass/v1',
 	API_LOCAL_BASE_URL: 'http://localhost:3001',
 	API_LOCAL_STORAGE: false,
 	OM_KLASS_URL: 'https://www.ssb.no/metadata/om-klass',

--- a/src/env/config/test_nocache/index.js
+++ b/src/env/config/test_nocache/index.js
@@ -4,7 +4,7 @@
 // changes should be done in the  /env/config/ files
 ////////////////////////////////////////////////////////////////////////////////////////////////
 const config = {
-	API_BASE_URL: 'http://ul-ssb-app-ekstern-test01.ssb.no:8080/api/klass/v1/',
+	API_BASE_URL: 'http://ul-ssb-app-ekstern-test01.ssb.no:8080/api/klass/v1',
 	API_LOCAL_BASE_URL: 'http://localhost:3001',
 	API_LOCAL_STORAGE: false,
 	OM_KLASS_URL: 'https://www.ssb.no/metadata/om-klass',

--- a/src/env/config/utv/index.js
+++ b/src/env/config/utv/index.js
@@ -4,7 +4,7 @@
 // changes should be done in the  /env/config/ files
 ////////////////////////////////////////////////////////////////////////////////////////////////
 const config = {
-	API_BASE_URL: 'https://data.utv.ssb.no/api/klass/v1/',
+	API_BASE_URL: 'https://data.utv.ssb.no/api/klass/v1',
 	API_LOCAL_BASE_URL: 'http://localhost:3001',
 	API_LOCAL_STORAGE: false,
 	OM_KLASS_URL: 'https://www.ssb.no/metadata/om-klass',

--- a/src/env/config/utv_nocache/index.js
+++ b/src/env/config/utv_nocache/index.js
@@ -4,7 +4,7 @@
 // changes should be done in the  /env/config/ files
 ////////////////////////////////////////////////////////////////////////////////////////////////
 const config = {
-	API_BASE_URL: 'http://ul-ssb-app-ekstern-utv01.ssb.no:8080/api/klass/v1/',
+	API_BASE_URL: 'http://ul-ssb-app-ekstern-utv01.ssb.no:8080/api/klass/v1',
 	API_LOCAL_BASE_URL: 'http://localhost:3001',
 	API_LOCAL_STORAGE: false,
 	OM_KLASS_URL: 'https://www.ssb.no/metadata/om-klass',

--- a/src/js/config/index.js
+++ b/src/js/config/index.js
@@ -4,7 +4,7 @@
 // changes should be done in the  /env/config/ files
 ////////////////////////////////////////////////////////////////////////////////////////////////
 const config = {
-	API_BASE_URL: '//data.ssb.no/api/klass/v1/',
+	API_BASE_URL: '//data.ssb.no/api/klass/v1',
 	API_LOCAL_BASE_URL: 'http://localhost:3001',
 	API_LOCAL_STORAGE: false,
 	OM_KLASS_URL: 'https://www.ssb.no/metadata/om-klass',

--- a/src/js/config/index.js
+++ b/src/js/config/index.js
@@ -14,7 +14,7 @@ const config = {
 		NYNORSK: 'nn',
 		ENGLISH: 'en'
 	},
-    GA_TRACKING_ID:'UA-26520516-3'
+    GA_TRACKING_ID:'UA-26520516-2'
 }
 
 export default config;

--- a/src/js/config/index.js
+++ b/src/js/config/index.js
@@ -4,7 +4,7 @@
 // changes should be done in the  /env/config/ files
 ////////////////////////////////////////////////////////////////////////////////////////////////
 const config = {
-	API_BASE_URL: '//data.ssb.no/api/klass/v1',
+	API_BASE_URL: '//data.ssb.no/api/klass/v1/',
 	API_LOCAL_BASE_URL: 'http://localhost:3001',
 	API_LOCAL_STORAGE: false,
 	OM_KLASS_URL: 'https://www.ssb.no/metadata/om-klass',
@@ -14,7 +14,7 @@ const config = {
 		NYNORSK: 'nn',
 		ENGLISH: 'en'
 	},
-    GA_TRACKING_ID:'UA-26520516-2'
+    GA_TRACKING_ID:'UA-26520516-3'
 }
 
 export default config;


### PR DESCRIPTION
This PR will fix URLs with consecutive slashes like: `https://data.ssb.no/api/klass/v1//ssbsections?language=nb` which appears across all environments including production.

Spring's [StrictHttpFirewall](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/web/firewall/StrictHttpFirewall.html) doesn't allow consecutive slashes as it can be exploited by HTTP Verb tampering and XST attacks.

Since **Klass web** is the principal user of `Klass API` it should at least fix its own incorrect use of un-normalized URLs. It looks like the error is due to an extra slash at the end of the `API_BASE_URL` for all environments except local.