### PR TITLE
Tune down resources in test

### DIFF
--- a/.nais/test/nais.yaml
+++ b/.nais/test/nais.yaml
@@ -17,5 +17,8 @@ spec:
     max: 1
   resources:
     requests:
-      cpu: 50m
+      cpu: 5m
       memory: 32Mi
+    limits:
+      cpu: 10m
+      memory: 64Mi


### PR DESCRIPTION
The app is using extremely little resources so we can tune it to a much smaller size. We can see how this performs in test before moving on to prod.

![Screenshot 2025-03-19 at 11 02 48](https://github.com/user-attachments/assets/91746a47-5d06-4c24-be9c-a5cf1c0a486c)
