### PR TITLE
Fix info notes

### DIFF
--- a/src/js/components/Frame/frame.scss
+++ b/src/js/components/Frame/frame.scss
@@ -442,7 +442,13 @@ img.ssb-logo-mobile{
         margin-bottom: 30px;
     }
 }
-@media (min-width: 992px) {
+@media (min-width: 1268px) {
+    .container, .container-lg, .container-md, .container-sm {
+        max-width: 1200px;
+    }
+}
+
+@media (max-width: 992px) {
     .container, .container-lg, .container-md, .container-sm {
         max-width: 960px;
     }
@@ -450,19 +456,19 @@ img.ssb-logo-mobile{
 
 @media (min-width: 992px) {
     .container, .container-lg, .container-md, .container-sm {
-        max-width: 960px;
+        width: 100%;
     }
 }
 
 @media (min-width: 768px) {
     .container, .container-md, .container-sm {
-        max-width: 90%;
+        max-width: 95%;
     }
 }
 
 @media (max-width: 768px) {
     .container, .container-md, .container-sm {
-        max-width: 90%;
+        max-width: 95%;
         margin-left: auto;
         margin-right: auto;
     }
@@ -472,11 +478,6 @@ img.ssb-logo-mobile{
     
 }
 
-@media (min-width: 992px) {
-    .container, .container-lg, .container-md, .container-sm{
-        max-width: 960px;
-    }
-}
 
 @media (min-width: 1260px) {
     .container, .container-lg, .container-md, .container-sm, .container-xl {

--- a/src/js/components/Frame/frame.scss
+++ b/src/js/components/Frame/frame.scss
@@ -350,10 +350,6 @@ hr {
     overflow: visible;
 }
 
-.footerXP {
-  margin-top: 40px;
-}
-
 img.ssb-logo-mobile{
   height: 35px;
 }
@@ -495,9 +491,6 @@ img.ssb-logo-mobile{
 }
 
 @media (max-width:500px){
-  #navigation-path{
-    font-size: 1.5em;
-  }
   footer .footer-bottom-row .social-links>*  {
       font-size: 0.7rem;
       padding: 0;

--- a/src/js/components/List/List.scss
+++ b/src/js/components/List/List.scss
@@ -18,7 +18,6 @@
         }
 
 		li {
-			padding: 0;
 			border-bottom: 1px solid #bbb;
 
             &:first-child {

--- a/src/js/components/Notes/Notes.scss
+++ b/src/js/components/Notes/Notes.scss
@@ -5,7 +5,7 @@
     position: absolute;
     line-height: variables.$body-line-height;
     margin-top: -6em;
-    right: -32em;
+    right: -28em;
 
     .modal-content {
         position: relative;
@@ -72,6 +72,26 @@
     h5 {
         text-align: center;
         padding-bottom: 1em;
+    }
+}
+
+
+@media screen and (max-width: 1260px) {
+    .modal-notes {
+        margin-left: 5em;
+        right: 5em;
+        left: auto;
+
+        .modal-content {
+            width: auto;
+
+            &:after {
+                right: -1.5em;
+                left: auto;
+                transform: rotate(90deg);
+
+            }
+        }
     }
 }
 

--- a/src/js/components/Notes/Notes.scss
+++ b/src/js/components/Notes/Notes.scss
@@ -5,7 +5,7 @@
     position: absolute;
     line-height: variables.$body-line-height;
     margin-top: -6em;
-    right: -35em;
+    right: -36em;
 
     .modal-content {
         position: relative;

--- a/src/js/components/Notes/Notes.scss
+++ b/src/js/components/Notes/Notes.scss
@@ -75,27 +75,7 @@
     }
 }
 
-
 @media screen and (max-width: 1260px) {
-    .modal-notes {
-        margin-left: 5em;
-        right: 5em;
-        left: auto;
-
-        .modal-content {
-            width: auto;
-
-            &:after {
-                right: -1.5em;
-                left: auto;
-                transform: rotate(90deg);
-
-            }
-        }
-    }
-}
-
-@media screen and (max-width: 700px) {
     .modal-notes {
         margin-left: 5em;
         right: 5em;

--- a/src/js/components/Notes/Notes.scss
+++ b/src/js/components/Notes/Notes.scss
@@ -5,14 +5,14 @@
     position: absolute;
     line-height: variables.$body-line-height;
     margin-top: -6em;
-    right: -28em;
+    right: -35em;
 
     .modal-content {
         position: relative;
         border: 1px solid color.scale(variables.$black, $lightness: 20%);
-        width: 20em;
+        width: 25em;
         outline: none;
-        padding: 20px;
+        padding: 25px;
         z-index: 100;
         font-size: variables.$body-font-size;
         background-color: color.scale(variables.$black, $lightness: 20%);

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -252,7 +252,6 @@ a:visited {
     left: -9999px;
 }
 .content {
-    overflow: hidden;
     max-width: 95em;
     width: 100%;
     margin-left: auto;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -252,6 +252,7 @@ a:visited {
     left: -9999px;
 }
 .content {
+    overflow: hidden;
     max-width: 95em;
     width: 100%;
     margin-left: auto;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -24,6 +24,7 @@ a:visited {
 }
 
 .klass {
+
     .clear-fix {
         clear: both;
     }
@@ -78,6 +79,7 @@ a:visited {
     }
 
     #page {
+        min-height: 75vh;
         ::-webkit-input-placeholder {
             font-style: italic;
         }
@@ -119,7 +121,6 @@ a:visited {
         .main {
             width: 67em;
             float: left;
-            margin-right: 3em;
 
             .heading {  
                 .description.short {
@@ -144,7 +145,6 @@ a:visited {
     .float-right-icon {
         float:right;
         margin-top: -7px;
-        position: static;
     }
 
     h1 {
@@ -237,7 +237,10 @@ a:visited {
 
 #page{
     margin-bottom: 0;
-    overflow: hidden;
+    margin: 0 1rem;
+    .content{
+        overflow: auto;
+    }
 } 
 .sitewrapper{
     margin: 0 auto;
@@ -252,7 +255,7 @@ a:visited {
     left: -9999px;
 }
 .content {
-    overflow: hidden;
+    overflow: auto;
     max-width: 95em;
     width: 100%;
     margin-left: auto;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -235,13 +235,6 @@ a:visited {
     }
 }
 
-#page{
-    margin-bottom: 0;
-    margin: 0 1rem;
-    .content{
-        overflow: auto;
-    }
-} 
 .sitewrapper{
     margin: 0 auto;
 }
@@ -254,13 +247,18 @@ a:visited {
     position: absolute;
     left: -9999px;
 }
-.content {
-    overflow: auto;
-    max-width: 100em;
-    width: 100%;
-    margin-left: auto;
-    margin-right: auto;
-}
+
+#page{
+    margin-bottom: 0;
+    margin: 0 1rem;
+    .content{
+        overflow: auto;
+        max-width: 110em;
+        width: 100%;
+        margin-left: auto;
+        margin-right: auto;
+    }
+} 
 
 div{   
     margin: 0;
@@ -309,7 +307,7 @@ ul.nav {
     font-size: 1.6em;
     margin-top: 1rem;
     width: 100%;
-    max-width: 1000px;
+    max-width: 1100px;
     margin-left: auto;
     margin-right: auto;
     margin-bottom: 3em;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -256,7 +256,7 @@ a:visited {
 }
 .content {
     overflow: auto;
-    max-width: 95em;
+    max-width: 100em;
     width: 100%;
     margin-left: auto;
     margin-right: auto;
@@ -309,15 +309,16 @@ ul.nav {
     font-size: 1.6em;
     margin-top: 1rem;
     width: 100%;
-    max-width: 950px;
+    max-width: 1000px;
     margin-left: auto;
     margin-right: auto;
     margin-bottom: 3em;
     overflow: hidden;
     display: flex;
-    align-items: center;
+    justify-content: flex-start;
     flex-wrap: wrap;
     gap: 0.5rem;
+    align-items: center;
     
     span{
         a{
@@ -333,10 +334,35 @@ ul.nav {
 }
 
 @media screen and (max-width: 500px) {
+    #navigation-path{
+        font-size: 1.5em;
+    }
     .klass #page h1 {
         font-size: 2em;
     }
     .klass{
         width: 100%;
     }
+}
+
+/* Chrome, Edge, Safari scrollbar */
+::-webkit-scrollbar {
+  width: 8px;              /* thinner scrollbar */
+  background-color: transparent;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent; /* no track background for minimal look */
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: rgba(100, 100, 100, 0.4);
+  border-radius: 4px;
+  border: 2px solid transparent; /* gives some padding */
+  background-clip: content-box;  /* ensure border doesn't cover thumb */
+  transition: background-color 0.3s;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(100, 100, 100, 0.7);
 }


### PR DESCRIPTION
Fix issue where info notes content is hidden.
Before:
![Screenshot 2025-06-18 at 13 07 05](https://github.com/user-attachments/assets/d0467110-7206-482b-8387-5a01ff8edb4e)

For wider screens page max width is increased (and affected boxes are adjusted accordingly), also info notes are slightly larger for better readability. 
Overflow is now auto and can scroll.

![Screenshot 2025-06-18 at 12 38 24](https://github.com/user-attachments/assets/226db3d2-e25d-491a-9472-d8acbd134197)

The breakpoint for when the info notes are positioned in the middle is changed so that also screens up to 1260px 
are included, this is a "safe" position

![Screenshot 2025-06-18 at 12 39 00](https://github.com/user-attachments/assets/b6ecb33a-e1ee-4c07-ae08-798c6539cf89)


Also fix issues with alignment long names:
Before:
![Screenshot 2025-06-18 at 13 02 37](https://github.com/user-attachments/assets/67b38810-ca55-436e-ab7f-2b460f4c540d)

After:
![Screenshot 2025-06-18 at 13 02 31](https://github.com/user-attachments/assets/c3330a21-91d7-4358-8bc6-23f8ec101f02)

