### PR TITLE
SHA1-HULUD mitigation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,21 +5,18 @@
 
 version: 2
 updates:
-
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-
-  - package-ecosystem: "maven"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
- Disable npm post-install scripts as recommended here: https://snyk.io/articles/npm-security-best-practices-shai-hulud-attack/
- Add cooldown for Dependabot to avoid upgrading to compromised package versions as recommended here: https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns
