### PR TITLE
Add null handling for Grype filtering steps

### DIFF
--- a/.github/workflows/grype-security-scan.yml
+++ b/.github/workflows/grype-security-scan.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - fix/grype-scan-null-iteration
   schedule:
     - cron: '0 0 * * *' # Runs every day at midnight
 jobs:

--- a/.github/workflows/grype-security-scan.yml
+++ b/.github/workflows/grype-security-scan.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - fix/grype-scan-null-iteration
   schedule:
     - cron: '0 0 * * *' # Runs every day at midnight
 jobs:
@@ -42,16 +43,26 @@ jobs:
       - name: Filter Docker SARIF (security-severity > 1.0, high/critical)
         run: |
           jq '
-            .runs |= map(
-              ( (.tool.driver.rules // []) | map({key: .id, value: .}) | from_entries ) as $rules
-              | .results |= map(
-                  select(
-                    (.level == "error")
-                    and (((($rules[.ruleId].properties["security-severity"] // "0") | try tonumber catch 0)) > 1.0)
-                  )
+            .runs = (
+              (.runs // [])
+              | map(
+                  .tool.driver.rules = (.tool.driver.rules // [])
+                  | ((.tool.driver.rules // []) | map({ key: (.id // ""), value: . }) | from_entries) as $rules
+                  | .results = (
+                      (.results // [])
+                      | map(
+                          select(
+                            ((.level // "") == "error")
+                            and ((((($rules[(.ruleId // "")].properties["security-severity"] // "0") | tostring) | try tonumber catch 0) > 1.0))
+                          )
+                        )
+                    )
+                  | (.results | map(.ruleId // empty) | unique) as $keep
+                  | .tool.driver.rules = (
+                      (.tool.driver.rules // [])
+                      | map(select((.id // "") as $id | ($keep | index($id))))
+                    )
                 )
-              | (.results | map(.ruleId) | unique) as $keep
-              | .tool.driver.rules |= map(select(.id as $id | $keep | index($id)))
             )
           ' "${{ steps.scan.outputs.sarif }}" > docker.filtered.sarif
 
@@ -77,19 +88,28 @@ jobs:
       - name: Filter SBOM SARIF (security-severity > 1.0, high/critical)
         run: |
           jq '
-            .runs |= map(
-              ( (.tool.driver.rules // []) | map({key: .id, value: .}) | from_entries ) as $rules
-              | .results |= map(
-                  select(
-                    (.level == "error")
-                    and (((($rules[.ruleId].properties["security-severity"] // "0") | try tonumber catch 0)) > 1.0)
-                  )
+            .runs = (
+              (.runs // [])
+              | map(
+                  .tool.driver.rules = (.tool.driver.rules // [])
+                  | ((.tool.driver.rules // []) | map({ key: (.id // ""), value: . }) | from_entries) as $rules
+                  | .results = (
+                      (.results // [])
+                      | map(
+                          select(
+                            ((.level // "") == "error")
+                            and ((((($rules[(.ruleId // "")].properties["security-severity"] // "0") | tostring) | try tonumber catch 0) > 1.0))
+                          )
+                        )
+                    )
+                  | (.results | map(.ruleId // empty) | unique) as $keep
+                  | .tool.driver.rules = (
+                      (.tool.driver.rules // [])
+                      | map(select((.id // "") as $id | ($keep | index($id))))
+                    )
                 )
-              | (.results | map(.ruleId) | unique) as $keep
-              | .tool.driver.rules |= map(select(.id as $id | $keep | index($id)))
             )
           ' "${{ steps.scan_sbom.outputs.sarif }}" > sbom.filtered.sarif
-
             
       - name: Upload SBOM scan SARIF report
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2


### PR DESCRIPTION
Prevent Grype scan failures by adding null safeguards when processing filtering steps.

